### PR TITLE
detect possible attacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,16 +293,16 @@ class FakeApiGatewayLambda {
     const uriObj = url.parse(reqUrl, true)
     console.log('R', req.headers)
 
-    // if a referrer header is present,
+    // if a referer header is present,
     // check that the request is from a page we hosted
     // otherwise, the request could be a locally open web page.
     // which could be an attacker.
-    if (!this.enableCors && req.headers.referrer) {
+    if (!this.enableCors && req.headers.referer) {
       // eslint-disable-next-line node/no-deprecated-api
-      const refferer = url.parse(req.headers.referrer)
-      if (refferer.hostname !== 'localhost') {
+      const referer = url.parse(req.headers.referer)
+      if (referer.hostname !== 'localhost') {
         res.statusCode = 403
-        return res.end({ message: 'expected request from localhost' })
+        return res.end(JSON.stringify({ message: 'expected request from localhost' }, null, 2))
       }
       // allow other ports. locally running apps are trusted, because the user had to start them.
     }
@@ -312,7 +312,7 @@ class FakeApiGatewayLambda {
     if (req.headers.host && req.headers.host.split(':')[0] !== 'localhost') {
       // error - dns poisoning attack
       res.statusCode = 403
-      return res.end({ message: 'unexpected host header' })
+      return res.end(JSON.stringify({ message: 'unexpected host header' }, null, 2))
     }
 
     let body = ''

--- a/test/errors.js
+++ b/test/errors.js
@@ -44,18 +44,22 @@ tape('runtime error', async (t) => {
 })
 
 tape('dns-poison', async (t) => {
-  const result = await fetch(`http://${gateway.hostPort}/hello`, {headers: {
-    host: 'http://dns-poisoning-attack.com'
-  }})
+  const result = await fetch(`http://${gateway.hostPort}/hello`, {
+    headers: {
+      host: 'http://dns-poisoning-attack.com'
+    }
+  })
   console.log(result)
   t.equal(result.status, 403)
   t.end()
 })
 
 tape('local website attack', async (t) => {
-  const result = await fetch(`http://${gateway.hostPort}/hello`, {headers: {
-    referer: 'http://example.com'
-  }})
+  const result = await fetch(`http://${gateway.hostPort}/hello`, {
+    headers: {
+      referer: 'http://example.com'
+    }
+  })
   console.log(result)
   t.equal(result.status, 403)
   t.end()
@@ -67,8 +71,6 @@ tape('fetch syntax error', async (t) => {
   t.equal(result.status, 500)
   t.end()
 })
-
-
 
 tape('teardown', async (t) => {
   await gateway.close()


### PR DESCRIPTION
There are some ways that a browser can inadvertently be caused to make requests to localhost.
If you are building an app with a local http service, usually it's considered to be a privileged api,
but a browser can make requests to localhost, this could be by any webpage you happen to have open.
also, a dns poisoning attack can make a request to a domain actually be to 127.0.0.1,

checking the referer and host headers protects against this, but depends on specified browser behavior.
a local process, which has full control over http headers, could make a request that is indistinguishable from the local user,
but usually these need to be installed directly by the user and not just clicked on a link.