### PR TITLE
Handle node for windows

### DIFF
--- a/child-process-worker.js
+++ b/child-process-worker.js
@@ -150,8 +150,10 @@ class ChildProcessWorker {
       const parts = this.handler.split('.')
       const handlerField = parts[parts.length - 1]
 
+      const cmd = process.platform === 'win32' ? process.execPath : 'node'
+
       proc = childProcess.spawn(
-        'node',
+        cmd,
         [WORKER_PATH, this.entry, handlerField],
         {
           stdio: ['pipe', 'pipe', 'pipe'],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/node": "12.0.2",
     "collapsed-assert": "1.0.3",
     "git-hooks-plus": "1.0.1",
-    "node-fetch": "2.6.1",
+    "node-fetch": "2.6.7",
     "npm-bin-deps": "1.10.1",
     "tapzero": "0.6.1"
   },
@@ -42,6 +42,5 @@
       "type": "MIT",
       "url": "http://github.com/Raynos/fake-ses/raw/master/LICENSE"
     }
-  ],
-  "dependencies": {}
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fake-api-gateway-lambda",
-  "version": "5.3.9",
+  "version": "5.3.10",
   "description": "This is a testing utility for testing your lambda functions.",
   "scripts": {
     "tsc": "npr tsc -p jsconfig.json --maxNodeModuleJsDepth 0",


### PR DESCRIPTION
By spawning node we get access denied, using process.execPath
avoids this issue.